### PR TITLE
Updated README. Added a test for verifying NullReferenceException. The parser in MessageInfo has been modified to exclude the NullReferenceException

### DIFF
--- a/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
+++ b/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
@@ -57,6 +57,7 @@ namespace NetTelebot.Tests
             SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromForwardDate()");
             Assert.True(sendMessage.Ok);
 
+
             // typeof MessageInfo.ForwardDate
             var forwardDate = sendMessage.Result.ForwardDate;
             var forwardDateYear = sendMessage.Result.ForwardDate.Year;

--- a/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
+++ b/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
@@ -24,6 +24,44 @@ namespace NetTelebot.Tests
         }
 
         /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ForwardFrom"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToTheEmptyForwardFrom()
+        {
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToTheEmptyForwardFrom()");
+            Assert.True(sendMessage.Ok);
+
+            // typeof MessageInfo.ForwardFrom
+            var forwardFrom = sendMessage.Result.ForwardFrom;
+
+            // field MessageInfo.ForwardFrom
+            var id = sendMessage.Result.ForwardFrom.Id;
+            var firstName = sendMessage.Result.ForwardFrom.FirstName;
+            var lastName = sendMessage.Result.ForwardFrom.LastName;
+            var userName = sendMessage.Result.ForwardFrom.UserName;
+            var languageCode = sendMessage.Result.ForwardFrom.LanguageCode;
+
+            Console.WriteLine("TestAppealToTheEmptyForwardFrom():"
+                              + "\n sendMessage.Result.ForwardFrom: " + forwardFrom
+                              + "\n sendMessage.Result.ForwardFrom.Id: " + id
+                              + "\n sendMessage.Result.ForwardFrom.FirstName: " + firstName
+                              + "\n sendMessage.Result.ForwardFrom.LastName: " + lastName
+                              + "\n sendMessage.Result.ForwardFrom.UserName: " + userName
+                              + "\n sendMessage.Result.ForwardFrom.LanguageCode: " + languageCode);
+
+            //check instance MessageInfo.ForwardFrom
+            Assert.IsInstanceOf(typeof(UserInfo), forwardFrom);
+
+            //check MessageInfo.ForwardFrom.field
+            Assert.AreEqual(id, 0);
+            Assert.IsNull(firstName);
+            Assert.IsNull(lastName);
+            Assert.IsNull(userName);
+            Assert.IsNull(languageCode);
+        }
+
+        /// <summary>
         /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ForwardDateUnix"/>
         /// </summary>
         [Test]
@@ -656,7 +694,7 @@ namespace NetTelebot.Tests
         }
 
         /// <summary>
-        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.NewChatMember"/>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.LeftChatMember"/>
         /// </summary>
         [Test]
         public void TestAppealToTheEmptyLeftChatMember()

--- a/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
+++ b/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
@@ -24,6 +24,125 @@ namespace NetTelebot.Tests
         }
 
         /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ReplyToMessage"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToMigrateFromReplyToMessage()
+        {
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromReplyToMessage()");
+            Assert.True(sendMessage.Ok);
+
+            // typeof MessageInfo.ReplyToMessage
+            var message = sendMessage.Result.ReplyToMessage;
+
+            // field MessageInfo.PinnedMessage.field
+            var messageId = sendMessage.Result.ReplyToMessage.MessageId;
+            var from = sendMessage.Result.ReplyToMessage.From;
+            var date = sendMessage.Result.ReplyToMessage.Date;
+            var chat = sendMessage.Result.ReplyToMessage.Chat;
+            var forwardFrom = sendMessage.Result.ReplyToMessage.ForwardFrom;
+            //todo forward_from_chat
+            var forwardFromMessageId = sendMessage.Result.ReplyToMessage.ForwardFromMessageId;
+            var forwardDate = sendMessage.Result.ReplyToMessage.ForwardDate;
+            var replyToMessage = sendMessage.Result.ReplyToMessage.ReplyToMessage;
+            var editDate = sendMessage.Result.ReplyToMessage.EditDate;
+            var text = sendMessage.Result.ReplyToMessage.Text;
+            //todo entities
+            var audio = sendMessage.Result.ReplyToMessage.Audio;
+            var document = sendMessage.Result.ReplyToMessage.Document;
+            //todo game
+            var photo = sendMessage.Result.ReplyToMessage.Photo;
+            var sticker = sendMessage.Result.ReplyToMessage.Sticker;
+            var video = sendMessage.Result.ReplyToMessage.Video;
+            //todo Voice
+            //todo VideoNote
+            //todo NewChatMembers;
+            var caption = sendMessage.Result.ReplyToMessage.Caption;
+            var contact = sendMessage.Result.ReplyToMessage.Contact;
+            var location = sendMessage.Result.ReplyToMessage.Location;
+            //todo Venue
+            var newChatMember = sendMessage.Result.ReplyToMessage.NewChatMember;
+            var leftChatMember = sendMessage.Result.ReplyToMessage.LeftChatMember;
+            var newChatTitle = sendMessage.Result.ReplyToMessage.NewChatTitle;
+            var newChatPhoto = sendMessage.Result.ReplyToMessage.NewChatPhoto;
+            var deleteChatPhoto = sendMessage.Result.ReplyToMessage.DeleteChatPhoto;
+            var groupChatCreated = sendMessage.Result.ReplyToMessage.GroupChatCreated;
+            var superGroupChatCreated = sendMessage.Result.ReplyToMessage.SuperGroupChatCreated;
+            var channelChatCreated = sendMessage.Result.ReplyToMessage.ChannelChatCreated;
+            var migrateToChatId = sendMessage.Result.ReplyToMessage.MigrateToChatId;
+            var migrateFromChatId = sendMessage.Result.ReplyToMessage.MigrateFromChatId;
+            var pinnedMessage = sendMessage.Result.ReplyToMessage.PinnedMessage;
+            //todo Invoice
+            //todo SuceffulPayment
+
+            Console.WriteLine("TestAppealToMigrateFromReplyToMessage():"
+                              + "\n sendMessage.Result.ReplyToMessage: " + message
+                              + "\n sendMessage.Result.ReplyToMessage.MessageId: " + messageId
+                              + "\n sendMessage.Result.ReplyToMessage.From: " + from
+                              + "\n sendMessage.Result.ReplyToMessage.Date: " + date
+                              + "\n sendMessage.Result.ReplyToMessage.Chat: " + chat
+                              + "\n sendMessage.Result.ReplyToMessage.ForwardFrom: " + forwardFrom
+                              + "\n sendMessage.Result.ReplyToMessage.ForwardFromMessageId: " + forwardFromMessageId
+                              + "\n sendMessage.Result.ReplyToMessage.ReplyToMessage: " + replyToMessage
+                              + "\n sendMessage.Result.ReplyToMessage.EditDate: " + editDate
+                              + "\n sendMessage.Result.ReplyToMessage.Text: " + text
+                              + "\n sendMessage.Result.ReplyToMessage.Audio: " + audio
+                              + "\n sendMessage.Result.ReplyToMessage.Document: " + document
+                              + "\n sendMessage.Result.ReplyToMessage.Photo: " + photo
+                              + "\n sendMessage.Result.ReplyToMessage.Sticker " + sticker
+                              + "\n sendMessage.Result.ReplyToMessage.Video: " + video
+                              + "\n sendMessage.Result.ReplyToMessage.Caption: " + caption
+                              + "\n sendMessage.Result.ReplyToMessage.Contact: " + contact
+                              + "\n sendMessage.Result.ReplyToMessage.Location: " + location
+                              + "\n sendMessage.Result.ReplyToMessage.NewChatMember: " + newChatMember
+                              + "\n sendMessage.Result.ReplyToMessage.LeftChatMember: " + leftChatMember
+                              + "\n sendMessage.Result.ReplyToMessage.NewChatTitle: " + newChatTitle
+                              + "\n sendMessage.Result.ReplyToMessage.NewChatPhoto: " + newChatPhoto
+                              + "\n sendMessage.Result.ReplyToMessage.DeleteChatPhoto: " + deleteChatPhoto
+                              + "\n sendMessage.Result.ReplyToMessage.GroupChatCreated: " + groupChatCreated
+                              + "\n sendMessage.Result.ReplyToMessage.SuperGroupChatCreated: " + superGroupChatCreated
+                              + "\n sendMessage.Result.ReplyToMessage.ChannelChatCreated: " + channelChatCreated
+                              + "\n sendMessage.Result.ReplyToMessage.MigrateToChatId: " + migrateToChatId
+                              + "\n sendMessage.Result.ReplyToMessage.MigrateFromChatId: " + migrateFromChatId
+                              + "\n sendMessage.Result.ReplyToMessage.PinnedMessage: " + pinnedMessage);
+
+            //check instance MessageInfo.PinnedMesage
+            Assert.IsInstanceOf(typeof(MessageInfo), message);
+
+            //check MessageInfo.PinnedMesage.field
+            Assert.AreEqual(messageId, 0);
+            Assert.IsNull(from);
+            Assert.AreEqual(date, DateTime.MinValue);
+            Assert.IsNull(chat);
+            Assert.IsNull(forwardFrom);
+            Assert.AreEqual(forwardFromMessageId, 0);
+            Assert.AreEqual(forwardDate, DateTime.MinValue);
+            Assert.IsNull(replyToMessage);
+            Assert.AreEqual(editDate, DateTime.MinValue);
+            Assert.IsNull(text);
+            Assert.IsNull(audio);
+            Assert.IsNull(document);
+            Assert.IsNull(photo);
+            Assert.IsNull(sticker);
+            Assert.IsNull(video);
+            Assert.IsNull(caption);
+            Assert.IsNull(contact);
+            Assert.IsNull(location);
+            Assert.IsNull(newChatMember);
+            Assert.IsNull(leftChatMember);
+            Assert.IsNull(leftChatMember);
+            Assert.IsNull(newChatTitle);
+            Assert.IsNull(newChatPhoto);
+            Assert.IsFalse(deleteChatPhoto);
+            Assert.IsFalse(groupChatCreated);
+            Assert.IsFalse(superGroupChatCreated);
+            Assert.IsFalse(channelChatCreated);
+            Assert.AreEqual(migrateToChatId, 0);
+            Assert.AreEqual(migrateFromChatId, 0);
+            Assert.IsNull(pinnedMessage);
+        }
+
+        /// <summary>
         /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ForwardFromMessageId"/>
         /// </summary>
         [Test]

--- a/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
+++ b/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
@@ -29,16 +29,16 @@ namespace NetTelebot.Tests
         [Test]
         public void TestAppealToMigrateFromForwardDateUnix()
         {
-            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromForwardDateUnix");
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromForwardDateUnix()");
             Assert.True(sendMessage.Ok);
 
             // typeof MessageInfo.ForwardDate
             var forwardDateUnix = sendMessage.Result.ForwardDateUnix;
             var forwardDateString = sendMessage.Result.ForwardDateUnix.ToString();
             
-            Console.WriteLine("TestAppealToMigrateFromForwardDateUnix:"
-                              + "\n sendMessage.Result.ReplyToMessage: " + forwardDateUnix
-                              + "\n sendMessage.Result.ReplyToMessage.MessageId: " + forwardDateString);
+            Console.WriteLine("TestAppealToMigrateFromForwardDateUnix():"
+                              + "\n sendMessage.Result.ForwardDateUnix: " + forwardDateUnix
+                              + "\n sendMessage.Result.ForwardDateUnix.ToString(): " + forwardDateString);
 
             //check instance MessageInfo.ForwardDate
             Assert.IsInstanceOf(typeof(int), forwardDateUnix);
@@ -57,18 +57,18 @@ namespace NetTelebot.Tests
             SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromForwardDate()");
             Assert.True(sendMessage.Ok);
 
-
             // typeof MessageInfo.ForwardDate
             var forwardDate = sendMessage.Result.ForwardDate;
+
             var forwardDateYear = sendMessage.Result.ForwardDate.Year;
             var forwardDateMonth = sendMessage.Result.ForwardDate.Month;
             var forwardDateDay = sendMessage.Result.ForwardDate.Day;
 
-            Console.WriteLine("TestAppealToMigrateFromReplyToMessage():"
-                              + "\n sendMessage.Result.ReplyToMessage: " + forwardDate
-                              + "\n sendMessage.Result.ReplyToMessage.MessageId: " + forwardDateYear
-                              + "\n sendMessage.Result.ReplyToMessage.From: " + forwardDateMonth
-                              + "\n sendMessage.Result.ReplyToMessage.Date: " + forwardDateDay);
+            Console.WriteLine("TestAppealToMigrateFromForwardDate():"
+                              + "\n sendMessage.Result.ForwardDate: " + forwardDate
+                              + "\n sendMessage.Result.ForwardDate.Year: " + forwardDateYear
+                              + "\n sendMessage.Result.ForwardDate.Month: " + forwardDateMonth
+                              + "\n sendMessage.Result.ForwardDate.Day: " + forwardDateDay);
 
             //check instance MessageInfo.ForwardDate
             Assert.IsInstanceOf(typeof(DateTime), forwardDate);
@@ -197,6 +197,63 @@ namespace NetTelebot.Tests
             Assert.AreEqual(migrateToChatId, 0);
             Assert.AreEqual(migrateFromChatId, 0);
             Assert.IsNull(pinnedMessage);
+        }
+
+        /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.EditDateUnix"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToMigrateFromEditDateUnix()
+        {
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromEditDateUnix()");
+            Assert.True(sendMessage.Ok);
+
+            // typeof MessageInfo.ForwardDate
+            var editDateUnix = sendMessage.Result.EditDateUnix;
+            var editDateString = sendMessage.Result.EditDateUnix.ToString();
+
+            Console.WriteLine("TestAppealToMigrateFromEditDateUnix():"
+                              + "\n sendMessage.Result.EditDateUnix: " + editDateUnix
+                              + "\n sendMessage.Result.EditDateUnix.ToString(): " + editDateString);
+
+            //check instance MessageInfo.ForwardDate
+            Assert.IsInstanceOf(typeof(int), editDateUnix);
+
+            //check value MessageInfo.ForwardDate
+            Assert.AreEqual(editDateUnix, 0);
+            Assert.AreEqual(editDateString, "0");
+        }
+
+        /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.EditDate"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToMigrateFromEditDate()
+        {
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromEditDate()");
+            Assert.True(sendMessage.Ok);
+
+            // typeof MessageInfo.ForwardDate
+            var editDate = sendMessage.Result.EditDate;
+
+            var editDateYear = sendMessage.Result.EditDate.Year;
+            var editDateMonth = sendMessage.Result.EditDate.Month;
+            var editDateDay = sendMessage.Result.EditDate.Day;
+
+            Console.WriteLine("TestAppealToMigrateFromEditDate():"
+                              + "\n sendMessage.Result.EditDate: " + editDate
+                              + "\n sendMessage.Result.EditDate.Year: " + editDateYear
+                              + "\n endMessage.Result.EditDate.Month: " +  editDateMonth
+                              + "\n sendMessage.Result.EditDate.Day: " +  editDateDay);
+
+            //check instance MessageInfo.ForwardDate
+            Assert.IsInstanceOf(typeof(DateTime), editDate);
+
+            //check value MessageInfo.ForwardDate
+            Assert.AreEqual(editDate, DateTime.MinValue);
+            Assert.AreEqual(editDateYear, 0001);
+            Assert.AreEqual(editDateMonth, 01);
+            Assert.AreEqual(editDateDay, 01);
         }
 
         /// <summary>

--- a/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
+++ b/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
@@ -24,6 +24,181 @@ namespace NetTelebot.Tests
         }
 
         /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ForwardDateUnix"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToMigrateFromForwardDateUnix()
+        {
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromForwardDateUnix");
+            Assert.True(sendMessage.Ok);
+
+            // typeof MessageInfo.ForwardDate
+            var forwardDateUnix = sendMessage.Result.ForwardDateUnix;
+            var forwardDateString = sendMessage.Result.ForwardDateUnix.ToString();
+            
+            Console.WriteLine("TestAppealToMigrateFromForwardDateUnix:"
+                              + "\n sendMessage.Result.ReplyToMessage: " + forwardDateUnix
+                              + "\n sendMessage.Result.ReplyToMessage.MessageId: " + forwardDateString);
+
+            //check instance MessageInfo.ForwardDate
+            Assert.IsInstanceOf(typeof(int), forwardDateUnix);
+
+            //check value MessageInfo.ForwardDate
+            Assert.AreEqual(forwardDateUnix, 0);
+            Assert.AreEqual(forwardDateString, "0");
+        }
+
+        /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ForwardDate"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToMigrateFromForwardDate()
+        {
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromForwardDate()");
+            Assert.True(sendMessage.Ok);
+
+            // typeof MessageInfo.ForwardDate
+            var forwardDate = sendMessage.Result.ForwardDate;
+            var forwardDateYear = sendMessage.Result.ForwardDate.Year;
+            var forwardDateMonth = sendMessage.Result.ForwardDate.Month;
+            var forwardDateDay = sendMessage.Result.ForwardDate.Day;
+
+            Console.WriteLine("TestAppealToMigrateFromReplyToMessage():"
+                              + "\n sendMessage.Result.ReplyToMessage: " + forwardDate
+                              + "\n sendMessage.Result.ReplyToMessage.MessageId: " + forwardDateYear
+                              + "\n sendMessage.Result.ReplyToMessage.From: " + forwardDateMonth
+                              + "\n sendMessage.Result.ReplyToMessage.Date: " + forwardDateDay);
+
+            //check instance MessageInfo.ForwardDate
+            Assert.IsInstanceOf(typeof(DateTime), forwardDate);
+
+            //check value MessageInfo.ForwardDate
+            Assert.AreEqual(forwardDate, DateTime.MinValue);
+            Assert.AreEqual(forwardDateYear, 0001);
+            Assert.AreEqual(forwardDateMonth, 01);
+            Assert.AreEqual(forwardDateDay, 01);
+        }
+
+        /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ReplyToMessage"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToMigrateFromReplyToMessage()
+        {
+            SendMessageResult sendMessage = mTelegramBot.SendMessage(mChatId, "TestAppealToMigrateFromReplyToMessage()");
+            Assert.True(sendMessage.Ok);
+
+            // typeof MessageInfo.ReplyToMessage
+            var message = sendMessage.Result.ReplyToMessage;
+
+            // field MessageInfo.PinnedMessage.field
+            var messageId = sendMessage.Result.ReplyToMessage.MessageId;
+            var from = sendMessage.Result.ReplyToMessage.From;
+            var date = sendMessage.Result.ReplyToMessage.Date;
+            var chat = sendMessage.Result.ReplyToMessage.Chat;
+            var forwardFrom = sendMessage.Result.ReplyToMessage.ForwardFrom;
+            //todo forward_from_chat
+            var forwardFromMessageId = sendMessage.Result.ReplyToMessage.ForwardFromMessageId;
+            var forwardDate = sendMessage.Result.ReplyToMessage.ForwardDate;
+            var replyToMessage = sendMessage.Result.ReplyToMessage.ReplyToMessage;
+            var editDate = sendMessage.Result.ReplyToMessage.EditDate;
+            var text = sendMessage.Result.ReplyToMessage.Text;
+            //todo entities
+            var audio = sendMessage.Result.ReplyToMessage.Audio;
+            var document = sendMessage.Result.ReplyToMessage.Document;
+            //todo game
+            var photo = sendMessage.Result.ReplyToMessage.Photo;
+            var sticker = sendMessage.Result.ReplyToMessage.Sticker;
+            var video = sendMessage.Result.ReplyToMessage.Video;
+            //todo Voice
+            //todo VideoNote
+            //todo NewChatMembers;
+            var caption = sendMessage.Result.ReplyToMessage.Caption;
+            var contact = sendMessage.Result.ReplyToMessage.Contact;
+            var location = sendMessage.Result.ReplyToMessage.Location;
+            //todo Venue
+            var newChatMember = sendMessage.Result.ReplyToMessage.NewChatMember;
+            var leftChatMember = sendMessage.Result.ReplyToMessage.LeftChatMember;
+            var newChatTitle = sendMessage.Result.ReplyToMessage.NewChatTitle;
+            var newChatPhoto = sendMessage.Result.ReplyToMessage.NewChatPhoto;
+            var deleteChatPhoto = sendMessage.Result.ReplyToMessage.DeleteChatPhoto;
+            var groupChatCreated = sendMessage.Result.ReplyToMessage.GroupChatCreated;
+            var superGroupChatCreated = sendMessage.Result.ReplyToMessage.SuperGroupChatCreated;
+            var channelChatCreated = sendMessage.Result.ReplyToMessage.ChannelChatCreated;
+            var migrateToChatId = sendMessage.Result.ReplyToMessage.MigrateToChatId;
+            var migrateFromChatId = sendMessage.Result.ReplyToMessage.MigrateFromChatId;
+            var pinnedMessage = sendMessage.Result.ReplyToMessage.PinnedMessage;
+            //todo Invoice
+            //todo SuceffulPayment
+
+            Console.WriteLine("TestAppealToMigrateFromReplyToMessage():"
+                              + "\n sendMessage.Result.ReplyToMessage: " + message
+                              + "\n sendMessage.Result.ReplyToMessage.MessageId: " + messageId
+                              + "\n sendMessage.Result.ReplyToMessage.From: " + from
+                              + "\n sendMessage.Result.ReplyToMessage.Date: " + date
+                              + "\n sendMessage.Result.ReplyToMessage.Chat: " + chat
+                              + "\n sendMessage.Result.ReplyToMessage.ForwardFrom: " + forwardFrom
+                              + "\n sendMessage.Result.ReplyToMessage.ForwardFromMessageId: " + forwardFromMessageId
+                              + "\n sendMessage.Result.ReplyToMessage.ReplyToMessage: " + replyToMessage
+                              + "\n sendMessage.Result.ReplyToMessage.EditDate: " + editDate
+                              + "\n sendMessage.Result.ReplyToMessage.Text: " + text
+                              + "\n sendMessage.Result.ReplyToMessage.Audio: " + audio
+                              + "\n sendMessage.Result.ReplyToMessage.Document: " + document
+                              + "\n sendMessage.Result.ReplyToMessage.Photo: " + photo
+                              + "\n sendMessage.Result.ReplyToMessage.Sticker " + sticker
+                              + "\n sendMessage.Result.ReplyToMessage.Video: " + video
+                              + "\n sendMessage.Result.ReplyToMessage.Caption: " + caption
+                              + "\n sendMessage.Result.ReplyToMessage.Contact: " + contact
+                              + "\n sendMessage.Result.ReplyToMessage.Location: " + location
+                              + "\n sendMessage.Result.ReplyToMessage.NewChatMember: " + newChatMember
+                              + "\n sendMessage.Result.ReplyToMessage.LeftChatMember: " + leftChatMember
+                              + "\n sendMessage.Result.ReplyToMessage.NewChatTitle: " + newChatTitle
+                              + "\n sendMessage.Result.ReplyToMessage.NewChatPhoto: " + newChatPhoto
+                              + "\n sendMessage.Result.ReplyToMessage.DeleteChatPhoto: " + deleteChatPhoto
+                              + "\n sendMessage.Result.ReplyToMessage.GroupChatCreated: " + groupChatCreated
+                              + "\n sendMessage.Result.ReplyToMessage.SuperGroupChatCreated: " + superGroupChatCreated
+                              + "\n sendMessage.Result.ReplyToMessage.ChannelChatCreated: " + channelChatCreated
+                              + "\n sendMessage.Result.ReplyToMessage.MigrateToChatId: " + migrateToChatId
+                              + "\n sendMessage.Result.ReplyToMessage.MigrateFromChatId: " + migrateFromChatId
+                              + "\n sendMessage.Result.ReplyToMessage.PinnedMessage: " + pinnedMessage);
+
+            //check instance MessageInfo.PinnedMesage
+            Assert.IsInstanceOf(typeof(MessageInfo), message);
+
+            //check MessageInfo.PinnedMesage.field
+            Assert.AreEqual(messageId, 0);
+            Assert.IsNull(from);
+            Assert.AreEqual(date, DateTime.MinValue);
+            Assert.IsNull(chat);
+            Assert.IsNull(forwardFrom);
+            Assert.AreEqual(forwardFromMessageId, 0);
+            Assert.AreEqual(forwardDate, DateTime.MinValue);
+            Assert.IsNull(replyToMessage);
+            Assert.AreEqual(editDate, DateTime.MinValue);
+            Assert.IsNull(text);
+            Assert.IsNull(audio);
+            Assert.IsNull(document);
+            Assert.IsNull(photo);
+            Assert.IsNull(sticker);
+            Assert.IsNull(video);
+            Assert.IsNull(caption);
+            Assert.IsNull(contact);
+            Assert.IsNull(location);
+            Assert.IsNull(newChatMember);
+            Assert.IsNull(leftChatMember);
+            Assert.IsNull(leftChatMember);
+            Assert.IsNull(newChatTitle);
+            Assert.IsNull(newChatPhoto);
+            Assert.IsFalse(deleteChatPhoto);
+            Assert.IsFalse(groupChatCreated);
+            Assert.IsFalse(superGroupChatCreated);
+            Assert.IsFalse(channelChatCreated);
+            Assert.AreEqual(migrateToChatId, 0);
+            Assert.AreEqual(migrateFromChatId, 0);
+            Assert.IsNull(pinnedMessage);
+        }
+
+        /// <summary>
         /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ForwardFromMessageId"/>
         /// </summary>
         [Test]

--- a/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
+++ b/NetTelebot.Tests/MessageInfoNullRefExcTest.cs
@@ -295,6 +295,34 @@ namespace NetTelebot.Tests
         }
 
         /// <summary>
+        /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.Text"/>
+        /// </summary>
+        [Test]
+        public void TestAppealToTheEmptyText()
+        {
+            const float latitude = 37.0000114f;
+            const float longitude = 37.0000076f;
+
+            SendMessageResult sendLocation = mTelegramBot.SendLocation(mChatId, latitude, longitude);
+
+            // typeof MessageInfo.Text
+            var text = sendLocation.Result.Text;
+
+            var textToUpper = sendLocation.Result.Text.ToUpper();
+
+            Console.WriteLine("TestAppealToTheEmptyText():"
+                              + "\n sendLocation.Result.Text: " + text
+                              + "\n sendLocation.Result.Text.ToUpper(): " + textToUpper);
+
+            //check instance MessageInfo.Text
+            Assert.IsInstanceOf(typeof(string), text);
+
+            //check value MessageInfo.Text
+            Assert.IsEmpty(text);
+            Assert.IsEmpty(textToUpper);
+        }
+
+        /// <summary>
         /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.ForwardFromMessageId"/>
         /// </summary>
         [Test]
@@ -653,7 +681,6 @@ namespace NetTelebot.Tests
             Assert.AreEqual(latitude, 0);
             Assert.AreEqual(longitude, 0);
         }
-
 
         /// <summary>
         /// Checking for NullReferenceException when accessing null fields <see cref="MessageInfo.NewChatMember"/>
@@ -1025,12 +1052,10 @@ namespace NetTelebot.Tests
             Assert.IsNull(pinnedMessage);
         }
 
-
         [Test]
         public void TestAppealToTheNonEmptyContact()
         {
             //todo create test after add method SendContact
-        }
-        
+        }        
     }
 }

--- a/NetTelebot.Tests/NetTelebot.Tests.csproj
+++ b/NetTelebot.Tests/NetTelebot.Tests.csproj
@@ -26,6 +26,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/NetTelebot/MessageInfo.cs
+++ b/NetTelebot/MessageInfo.cs
@@ -41,8 +41,10 @@ namespace NetTelebot
             DateUnix = jsonObject["date"].Value<int>();
             Date = DateUnix.ToDateTime();
             Chat = ParseChat(jsonObject["chat"].Value<JObject>());
-            if (jsonObject["forward_from"] != null)
-                ForwardFrom = new UserInfo(jsonObject["forward_from"].Value<JObject>());
+
+            ForwardFrom = jsonObject["forward_from"] != null
+                ? new UserInfo(jsonObject["forward_from"].Value<JObject>())
+                : new UserInfo();
 
             if (jsonObject["forward_from_message_id"] != null)
                 ForwardFromMessageId = jsonObject["forward_from_message_id"].Value<int>();
@@ -62,6 +64,8 @@ namespace NetTelebot
                 EditDateUnix = jsonObject["edit_date"].Value<int>();
                 EditDate = EditDateUnix.ToDateTime();
             }
+
+            //todo need test
             if (jsonObject["text"] != null)
                 Text = jsonObject["text"].Value<string>();
 

--- a/NetTelebot/MessageInfo.cs
+++ b/NetTelebot/MessageInfo.cs
@@ -52,8 +52,11 @@ namespace NetTelebot
                 ForwardDateUnix = jsonObject["forward_date"].Value<int>();
                 ForwardDate = ForwardDateUnix.ToDateTime();
             }
-            if(jsonObject["reply_to_message"]!=null)
-                ReplyToMessage = new MessageInfo(jsonObject["reply_to_message"].Value<JObject>());
+            
+            ReplyToMessage = jsonObject["reply_to_message"] != null
+                ? new MessageInfo(jsonObject["reply_to_message"].Value<JObject>())
+                : new MessageInfo();
+
             if (jsonObject["edit_date"] != null)
             {
                 EditDateUnix = jsonObject["edit_date"].Value<int>();

--- a/NetTelebot/MessageInfo.cs
+++ b/NetTelebot/MessageInfo.cs
@@ -65,9 +65,9 @@ namespace NetTelebot
                 EditDate = EditDateUnix.ToDateTime();
             }
 
-            //todo need test
-            if (jsonObject["text"] != null)
-                Text = jsonObject["text"].Value<string>();
+            Text = jsonObject["text"] != null 
+                ? jsonObject["text"].Value<string>() 
+                : string.Empty;
 
             Audio = jsonObject["audio"] != null 
                 ? new AudioInfo(jsonObject["audio"].Value<JObject>()) 
@@ -180,57 +180,67 @@ namespace NetTelebot
         public IConversationSource Chat { get; private set; }
 
         /// <summary>
-        /// Optional. For forwarded messages, sender of the original message
+        /// Optional. For forwarded messages, sender of the original message.
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyForwardFrom()</remarks>
         public UserInfo ForwardFrom { get; private set; }
 
         //todo add (IConversationSource) ForwardFromChat
 
         /// <summary>
-        /// Optional. For forwarded channel posts, identifier of the original message in the channel
+        /// Optional. For forwarded channel posts, identifier of the original message in the channel 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyForwardFromMessageId()</remarks>
         public int ForwardFromMessageId { get; private set; }
 
         /// <summary>
         /// Optional. For forwarded messages, date the original message was sent in Unix time
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToMigrateFromForwardDateUnix()</remarks>
         public int ForwardDateUnix { get; private set; }
 
         /// <summary>
         /// Optional. For forwarded messages, date the original message was sent in Unix time
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToMigrateFromForwardDate()</remarks>
         public DateTime ForwardDate { get; private set; }
 
         /// <summary>
         /// Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToMigrateFromReplyToMessage()</remarks>
         public MessageInfo ReplyToMessage { get; private set; }
 
         /// <summary>
         /// Optional. Date the message was last edited in Unix time
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToMigrateFromEditDateUnix()</remarks>
         public int EditDateUnix { get; private set; }
 
         /// <summary>
-        /// Optional. Date the message was last edited
+        /// Optional. Date the message was last edited 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToMigrateFromEditDate()</remarks>
         public DateTime EditDate { get; private set; }
 
         /// <summary>
-        /// Optional. For text messages, the actual UTF-8 text of the message
+        /// Optional. For text messages, the actual UTF-8 text of the message 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyText()</remarks>
         public string Text { get; private set; }
 
         //todo add (MessageEntity) Entities
 
         /// <summary>
-        /// Optional. Message is an audio file, information about the file
+        /// Optional. Message is an audio file, information about the file TestAppealToTheEmptyAudio()
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyAudio()</remarks>
         public AudioInfo Audio { get; private set; }
 
         /// <summary>
-        /// Optional. Message is a general file, information about the file
+        /// Optional. Message is a general file, information about the file TestAppealToTheEmptyDocument()
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyDocument()</remarks>
         public DocumentInfo Document { get; private set; }
 
         //todo add (Game) Game
@@ -238,16 +248,19 @@ namespace NetTelebot
         /// <summary>
         /// Optional. Message is a photo, available sizes of the photo
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyPhoto()</remarks>
         public PhotoSizeInfo[] Photo { get; private set; }
 
         /// <summary>
-        /// Optional. Message is a sticker, information about the sticker
+        /// Optional. Message is a sticker, information about the sticker 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptySticker()</remarks>
         public StickerInfo Sticker { get; private set; }
 
         /// <summary>
-        /// Optional. Message is a video, information about the video
+        /// Optional. Message is a video, information about the video 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyVideo()</remarks>
         public VideoInfo Video { get; private set; }
 
         //todo add (Voice) Voice
@@ -256,83 +269,97 @@ namespace NetTelebot
 
 
         /// <summary>
-        /// Optional. Caption for the document, photo or video, 0-200 characters
+        /// Optional. Caption for the document, photo or video, 0-200 characters 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyCaption()</remarks>
         public string Caption { get; private set; }
 
         /// <summary>
-        /// Optional. Message is a shared contact, information about the contact
+        /// Optional. Message is a shared contact, information about the contact TestAppealToTheEmptyContact()
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyContact()</remarks>
         public ContactInfo Contact { get; private set; }
 
         /// <summary>
-        /// Optional. Message is a shared location, information about the location
+        /// Optional. Message is a shared location, information about the location 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyLocation()</remarks>
         public LocationInfo Location { get; private set; }
 
         //todo add (Venue) Venue
 
         /// <summary>
-        /// Optional. A new member was added to the group, information about them (this member may be bot itself)
+        /// Optional. A new member was added to the group, information about them (this member may be bot itself)  
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyNewChatMember()</remarks>
         public UserInfo NewChatMember { get; private set; }
 
         /// <summary>
-        /// Optional. A member was removed from the group, information about them (this member may be bot itself)
+        /// Optional. A member was removed from the group, information about them (this member may be bot itself) 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyLeftChatMember()</remarks>
         public UserInfo LeftChatMember { get; private set; }
 
         /// <summary>
-        /// Optional. A group title was changed to this value
+        /// Optional. A group title was changed to this value 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyNewChatTitle()</remarks>
         public string NewChatTitle { get; private set; }
 
         /// <summary>
-        /// Optional. A group photo was change to this value
+        /// Optional. A group photo was change to this value TestAppealToTheEmptyNewChatPhoto()
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyNewChatPhoto()</remarks>
         public PhotoSizeInfo[] NewChatPhoto { get; private set; }
 
         /// <summary>
-        /// Optional. Informs that the group photo was deleted
+        /// Optional. Informs that the group photo was deleted TestAppealToTheEmptyDeleteChatPhoto()
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheEmptyDeleteChatPhoto()</remarks>
         public bool DeleteChatPhoto { get; private set; }
 
         /// <summary>
-        /// Optional. Informs that the group has been created
+        /// Optional. Informs that the group has been created TestAppealToTheGroupChatCreated()
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToTheGroupChatCreated()</remarks>
         public bool GroupChatCreated { get; private set; }
 
         /// <summary>
         /// Optional. Service message: the supergroup has been created. This field can‘t be received in a message coming through updates,
         /// because bot can’t be a member of a supergroup when it is created. It can only be found in reply_to_message if someone replies to a very
-        /// first message in a directly created supergroup.
+        /// first message in a directly created supergroup. 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToSuperGroupChatCreated()</remarks>
         public bool SuperGroupChatCreated { get; private set;  }
 
         /// <summary>
         /// Optional. Service message: the channel has been created. This field can‘t be received in a message coming through updates, 
         /// because bot can’t be a member of a channel when it is created. It can only be found in reply_to_message if someone replies to a very
-        /// first message in a channel.
+        /// first message in a channel. TestAppealToChannelChatCreated()
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToChannelChatCreated()</remarks>
         public bool ChannelChatCreated { get; private set; }
 
         /// <summary>
         /// Optional. The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some
         /// programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision
-        /// float type are safe for storing this identifier.
+        /// float type are safe for storing this identifier. 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToMigrateToChatId()</remarks>
         public int MigrateToChatId { get; private set;  }
 
         /// <summary>
         /// Optional. The supergroup has been migrated from a group with the specified identifier. This number may be greater than 32 bits and some
         /// programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision
-        /// float type are safe for storing this identifier.
+        /// float type are safe for storing this identifier. 
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.TestAppealToMigrateFromChatId()</remarks>
         public int MigrateFromChatId { get; private set;  }
 
         /// <summary>
         /// Optional. Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
         /// </summary>
+        /// <remarks> Test NullReferenceException: NetTelebot.Tests.estAppealToMigrateFromPinnedMessage()</remarks>
         public MessageInfo PinnedMessage { get; private set; }
 
         //todo (Invoice) Invoice

--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Look at the [Wiki](https://github.com/themehrdad/NetTelebot/wiki)
 ## To Do
 
 Look at the [project page](https://github.com/vertigra/NetTelebot-2.0/projects/1)
+
+## License
+
+Usage is provided under the [MIT License](http://http//opensource.org/licenses/mit-license.php). See LICENSE for the full details


### PR DESCRIPTION
* Updated README
* Added a test for MessageInfo.ReplyToMessage verifying NullReferenceException
* Added a test for MessageInfo.ReplyToMessage verifying NullReferenceException
* Added a test for MessageInfo.ForwardDateUnix and MessageInfo.ForwardDate verifying NullReferenceException
* Added a test for MessageInfo.EditDateUnix and MessageInfo.EditDate verifying NullReferenceException
* Added a test for MessageInfo.ForwardFrom verifying NullReferenceException
* Added a test for MessageInfo.Text and verifying NullReferenceException.